### PR TITLE
Add optional session state handling and upgrade to .NET 8

### DIFF
--- a/ThroughputTest/SessionReceiverTask.cs
+++ b/ThroughputTest/SessionReceiverTask.cs
@@ -153,9 +153,21 @@ namespace ThroughputTest
             await semaphore.WaitAsync();
             try
             {
+                // Read session state if enabled
+                if (Settings.SessionStateSizeBytes > 0)
+                {
+                    _ = await serviceBusSessionReceiver.GetSessionStateAsync(CancellationToken.None);
+                }
+
                 if (Settings.WorkDuration > 0)
                 {
                     await Task.Delay(TimeSpan.FromMilliseconds(Settings.WorkDuration)).ConfigureAwait(false);
+                }
+                // Set session state if enabled
+                if (Settings.SessionStateSizeBytes > 0)
+                {
+                    byte[] newStateData = new byte[Settings.SessionStateSizeBytes];
+                    await serviceBusSessionReceiver.SetSessionStateAsync(new BinaryData(newStateData), CancellationToken.None);
                 }
 
                 await serviceBusSessionReceiver.CompleteMessageAsync(message);
@@ -209,9 +221,21 @@ namespace ThroughputTest
 
         private async Task ProcessProcessorMessage(ProcessSessionMessageEventArgs serviceBusSessionReceiver, ServiceBusReceivedMessage message)
         {
+            // Read session state if enabled
+            if (Settings.SessionStateSizeBytes > 0)
+            {
+                _ = await serviceBusSessionReceiver.GetSessionStateAsync(CancellationToken.None);
+            }
+
             if (Settings.WorkDuration > 0)
             {
                 await Task.Delay(TimeSpan.FromMilliseconds(Settings.WorkDuration)).ConfigureAwait(false);
+            }
+            // Set session state if enabled
+            if (Settings.SessionStateSizeBytes > 0)
+            {
+                byte[] newStateData = new byte[Settings.SessionStateSizeBytes];
+                await serviceBusSessionReceiver.SetSessionStateAsync(new BinaryData(newStateData), CancellationToken.None);
             }
             await serviceBusSessionReceiver.CompleteMessageAsync(message);
         }

--- a/ThroughputTest/SessionReceiverTask.cs
+++ b/ThroughputTest/SessionReceiverTask.cs
@@ -156,7 +156,13 @@ namespace ThroughputTest
                 // Read session state if enabled
                 if (Settings.SessionStateSizeBytes > 0)
                 {
-                    _ = await serviceBusSessionReceiver.GetSessionStateAsync(CancellationToken.None);
+                    var currentState = await serviceBusSessionReceiver.GetSessionStateAsync(CancellationToken.None);
+                    
+                    // Validate session state size if state exists
+                    if (currentState != null && currentState.ToArray().Length != Settings.SessionStateSizeBytes)
+                    {
+                        throw new Exception($"Session state size mismatch. Expected: {Settings.SessionStateSizeBytes}, Actual: {currentState.ToArray().Length}");
+                    }
                 }
 
                 if (Settings.WorkDuration > 0)
@@ -224,7 +230,13 @@ namespace ThroughputTest
             // Read session state if enabled
             if (Settings.SessionStateSizeBytes > 0)
             {
-                _ = await serviceBusSessionReceiver.GetSessionStateAsync(CancellationToken.None);
+                var currentState = await serviceBusSessionReceiver.GetSessionStateAsync(CancellationToken.None);
+                
+                // Validate session state size if state exists
+                if (currentState != null && currentState.ToArray().Length != Settings.SessionStateSizeBytes)
+                {
+                    throw new Exception($"Session state size mismatch. Expected: {Settings.SessionStateSizeBytes}, Actual: {currentState.ToArray().Length}");
+                }
             }
 
             if (Settings.WorkDuration > 0)

--- a/ThroughputTest/Settings.cs
+++ b/ThroughputTest/Settings.cs
@@ -75,6 +75,9 @@ namespace ThroughputTest
         [Option('l', "message ttl", Required = false, HelpText = "Message time to live in minutes")]
         public int MessageTimeToLiveMinutes { get; private set; } = 0;
 
+        [Option('z', "session-state-bytes", Required = false, HelpText = "Size of the session state in bytes to set (default 0, feature disabled if 0)")]
+        public int SessionStateSizeBytes { get; private set; } = 0;
+
         public void PrintSettings()
         {
             Console.WriteLine("Settings:");
@@ -94,6 +97,7 @@ namespace ThroughputTest
             Console.WriteLine("{0}: {1}", "WorkDuration", this.WorkDuration);
             Console.WriteLine("{0}: {1}", "MessageTimeToLiveMinutes", this.MessageTimeToLiveMinutes);
             Console.WriteLine("{0}: {1}", "SessionsNumber", this.SessionsNumber);
+            Console.WriteLine("{0}: {1}", "SessionStateSizeBytes", this.SessionStateSizeBytes);
             Console.WriteLine("{0}: {1}", "SendDelay", this.SendDelay);
             Console.WriteLine("{0}: {1}", "PrefetchCount", this.PrefetchCount);
 

--- a/ThroughputTest/ThroughputTest.csproj
+++ b/ThroughputTest/ThroughputTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net6.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 	</PropertyGroup>
 


### PR DESCRIPTION
- Introduce SessionStateSizeBytes setting to enable session state read/set
- Update SessionReceiverTask and processor to conditionally get and set session state when enabled
- Print SessionStateSizeBytes in settings output
- Bump target framework from net6.0 to net8.0