### PR TITLE
Add Entra ID auth

### DIFF
--- a/ThroughputTest/ReceiverTask.cs
+++ b/ThroughputTest/ReceiverTask.cs
@@ -15,6 +15,7 @@ namespace ThroughputTest
     using System.Threading;
     using System.Threading.Tasks;
     using Azure.Messaging.ServiceBus;
+    using Azure.Identity;
 
     sealed class ReceiverTask : PerformanceTask
     {
@@ -54,7 +55,18 @@ namespace ThroughputTest
 
         async Task ReceiveTask(string path)
         {
-            var client = new ServiceBusClient(this.Settings.ConnectionString);
+            ServiceBusClient client;
+            if (!string.IsNullOrWhiteSpace(this.Settings.ServiceBusNamespace))
+            {
+                // Use Entra ID authentication with DefaultAzureCredential
+                client = new ServiceBusClient(this.Settings.ServiceBusNamespace, new DefaultAzureCredential());
+            }
+            else
+            {
+                // Use connection string authentication
+                client = new ServiceBusClient(this.Settings.ConnectionString);
+            }
+            
             var options = new ServiceBusReceiverOptions();
             options.ReceiveMode = this.Settings.ReceiveMode;
             options.PrefetchCount = Settings.PrefetchCount;

--- a/ThroughputTest/SenderTask.cs
+++ b/ThroughputTest/SenderTask.cs
@@ -171,7 +171,6 @@ namespace ThroughputTest
         private async Task HandleExceptions(DynamicSemaphoreSlim semaphore, SendMetrics sendMetrics, AggregateException ex)
         {
             bool wait = false;
-            Console.WriteLine($"SenderTask: Exception occurred: {ex.Message}");
             ex.Handle((x) =>
             {
                 if (x is ServiceBusException sbException)

--- a/ThroughputTest/SessionReceiverTask.cs
+++ b/ThroughputTest/SessionReceiverTask.cs
@@ -128,7 +128,7 @@ namespace ThroughputTest
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine($"Error receiving messages from session {path}: {ex.Message}");
+
                         // receiveMetrics.ReceiveDuration100ns = sw.ElapsedTicks - nsec;
                         if (ex is ServiceBusException sbException && sbException.Reason == ServiceBusFailureReason.ServiceBusy)
                         {

--- a/ThroughputTest/ThroughputTest.csproj
+++ b/ThroughputTest/ThroughputTest.csproj
@@ -5,6 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Azure.Identity" Version="1.12.1" />
 		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
 		<PackageReference Include="CommandLineParser" Version="2.5.0" />
 		<PackageReference Include="LinqStatistics" Version="2.3.0" />


### PR DESCRIPTION
• Require either --sb-namespace or --connection-string, not both
• Validate and error on missing send path for namespace auth
• Support DefaultAzureCredential when ServiceBusNamespace is used
• Update Settings and tasks to handle dual auth methods
